### PR TITLE
Move vite to dependencies and update host

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "vite",
+    "start": "vite --host",
     "dev": "vite",
     "build": "run-p type-check build-only",
     "preview": "vite preview",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "@vitejs/plugin-vue": "^4.2.3",
     "vite": "^4.4.6",
     "vue": "^3.3.4",
     "vue-router": "^4.2.4"
@@ -25,7 +26,6 @@
     "@rushstack/eslint-patch": "^1.3.2",
     "@tsconfig/node18": "^18.2.0",
     "@types/node": "^18.17.0",
-    "@vitejs/plugin-vue": "^4.2.3",
     "@vue/eslint-config-prettier": "^8.0.0",
     "@vue/eslint-config-typescript": "^11.0.3",
     "@vue/tsconfig": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "vite": "^4.4.6",
     "vue": "^3.3.4",
     "vue-router": "^4.2.4"
   },
@@ -36,7 +37,6 @@
     "prettier": "^3.0.0",
     "start-server-and-test": "^2.0.0",
     "typescript": "~5.1.6",
-    "vite": "^4.4.6",
     "vue-tsc": "^1.8.6"
   }
 }


### PR DESCRIPTION
Vite wasn't in the primary dependencies, so this package wasn't working on buildpacks or in production builds. This moves Vite to standard deps and adds the `--host` arg to mount to the host machine.